### PR TITLE
Allow override of combineReducers

### DIFF
--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -1,5 +1,5 @@
 import createSagaMiddleware from 'redux-saga';
-import { combineReducers, createStore, applyMiddleware } from 'redux';
+import { combineReducers as reduxCombineReducers, createStore, applyMiddleware } from 'redux';
 
 const RESET_TESTER_ACTION_TYPE = '@@RESET_TESTER';
 const makeResettable = (reducer, initialStateSlice) => (state, action) => {
@@ -13,7 +13,7 @@ const makeResettable = (reducer, initialStateSlice) => (state, action) => {
 export const resetAction = { type : RESET_TESTER_ACTION_TYPE };
 
 export default class SagaIntegrationTester {
-    constructor({initialState = {}, reducers, middlewares = []}) {
+    constructor({initialState = {}, reducers, middlewares = [], combineReducer = reduxCombineReducers}) {
         this.actionsCalled  = [];
         this.actionLookups  = {};
         this.sagaMiddleware = createSagaMiddleware();


### PR DESCRIPTION
Our setup uses [redux-undo](https://github.com/omnidan/redux-undo) which requires that we wrap the `combineReducers` result in an `undoable` call. The `undoable` function changes the shape of our state, so it needs to be in place for our selectors to work correctly. 

This change allows us to optionally pass in `combineReducers` via `SagaTester` constructor. I think the rest of the world could find use in this as well. Namely anyone using `redux-undo`.