### PR TITLE
support for reducer functions

### DIFF
--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -13,7 +13,7 @@ const makeResettable = (reducer, initialStateSlice) => (state, action) => {
 export const resetAction = { type : RESET_TESTER_ACTION_TYPE };
 
 export default class SagaIntegrationTester {
-    constructor({initialState = {}, reducer, reducers, middlewares = [], combineReducers = reduxCombineReducers}) {
+    constructor({initialState = {}, reducers, middlewares = [], combineReducers = reduxCombineReducers}) {
         this.actionsCalled  = [];
         this.actionLookups  = {};
         this.sagaMiddleware = createSagaMiddleware();

--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -13,18 +13,26 @@ const makeResettable = (reducer, initialStateSlice) => (state, action) => {
 export const resetAction = { type : RESET_TESTER_ACTION_TYPE };
 
 export default class SagaIntegrationTester {
-    constructor({initialState = {}, reducers, middlewares = [], combineReducers = reduxCombineReducers}) {
+    constructor({initialState = {}, reducer, reducers, middlewares = [], combineReducers = reduxCombineReducers}) {
         this.actionsCalled  = [];
         this.actionLookups  = {};
         this.sagaMiddleware = createSagaMiddleware();
 
-        // Wrap reducers so they can be reset, or supply identity reducer as default
-        const finalReducer = reducers
-            ? combineReducers(Object.keys(reducers).reduce((rc, reducerName) => ({
-                    ...rc,
-                    [reducerName] : makeResettable(reducers[reducerName], initialState[reducerName])
-                }), {}))
-            : state => state;
+
+        const finalReducer = (() => {
+          // supply identity reducer as default
+          console.log('final reducer')
+          if (!reducers) return state => state;
+          console.log('checking if function', typeof reducers)
+          // use reducer function if already provided
+          if (typeof reducers === 'function') return reducers;
+          // .. or, wrap reducers so they can be reset
+          console.log('wrapping')
+          return combineReducers(Object.keys(reducers).reduce((rc, reducerName) => ({
+              ...rc,
+              [reducerName] : makeResettable(reducers[reducerName], initialState[reducerName])
+          }), {}));
+        })();
 
         // Middleware to store the actions and create promises
         const testerMiddleware = store => next => action => {

--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -18,16 +18,12 @@ export default class SagaIntegrationTester {
         this.actionLookups  = {};
         this.sagaMiddleware = createSagaMiddleware();
 
-
         const finalReducer = (() => {
           // supply identity reducer as default
-          console.log('final reducer')
           if (!reducers) return state => state;
-          console.log('checking if function', typeof reducers)
           // use reducer function if already provided
           if (typeof reducers === 'function') return reducers;
           // .. or, wrap reducers so they can be reset
-          console.log('wrapping')
           return combineReducers(Object.keys(reducers).reduce((rc, reducerName) => ({
               ...rc,
               [reducerName] : makeResettable(reducers[reducerName], initialState[reducerName])

--- a/test/SagaTester.spec.js
+++ b/test/SagaTester.spec.js
@@ -104,6 +104,21 @@ describe('SagaTester', () => {
 		expect(sagaTester.getActionsCalled()).to.deep.equal([]);
 	});
 
+  it('Resets the state of the store to the initial state when using a reducer function', () => {
+		const someFinalValue = 'SOME_FINAL_VALUE';
+		const reducers = (state = {someKey: someInitialValue}, action) =>
+			(action.type === someActionType ? {someKey: someFinalValue} : state)
+
+		const sagaTester = new SagaTester({initialState : someInitialState, reducers});
+		sagaTester.dispatch(someAction);
+		expect(sagaTester.getState()).to.deep.equal({someKey : someFinalValue});
+		expect(sagaTester.getActionsCalled()).to.deep.equal([someAction]);
+
+		sagaTester.reset(true);
+		expect(sagaTester.getState()).to.deep.equal(someInitialState);
+		expect(sagaTester.getActionsCalled()).to.deep.equal([]);
+  });
+
 	it('Returns whether or not an action was called', () => {
 		const sagaTester = new SagaTester({});
 		expect(sagaTester.wasCalled(someActionType)).to.equal(false);

--- a/test/SagaTester.spec.js
+++ b/test/SagaTester.spec.js
@@ -39,6 +39,15 @@ describe('SagaTester', () => {
 		expect(sagaTester.getState()).to.deep.equal({someKey : someFinalValue});
 	});
 
+  it('uses a reducer as a function if provided', () => {
+    let wasReducerCalled = false;
+    const reducerFn = () => wasReducerCalled = true;
+
+    const sagaTester = new SagaTester({reducers: reducerFn})
+		sagaTester.dispatch(someAction);
+		expect(wasReducerCalled).to.be.true;
+  })
+
 	it('Uses the supplied middlewares', () => {
 		let flag = false;
 		const middlewares = [


### PR DESCRIPTION
This adds support for passing a global reducer function to be used, instead of repeating the key/value pairs for `combineReducers`.

Test added for support, however I'm not sure what the `makeResettable` functionality is and if that can be applied here?
