### PR TITLE
Added ignoreReduxActions flag

### DIFF
--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -13,7 +13,8 @@ const makeResettable = (reducer, initialStateSlice) => (state, action) => {
 export const resetAction = { type : RESET_TESTER_ACTION_TYPE };
 
 export default class SagaIntegrationTester {
-    constructor({initialState = {}, reducers, middlewares = [], combineReducers = reduxCombineReducers}) {
+    constructor({initialState = {}, reducers, middlewares = [],
+            combineReducers = reduxCombineReducers, ignoreReduxActions = true}) {
         this.actionsCalled  = [];
         this.actionLookups  = {};
         this.sagaMiddleware = createSagaMiddleware();
@@ -28,8 +29,9 @@ export default class SagaIntegrationTester {
 
         // Middleware to store the actions and create promises
         const testerMiddleware = store => next => action => {
-            // Don't monitor redux actions
-            if (!action.type.startsWith('@@redux')) {
+            if (ignoreReduxActions && action.type.startsWith('@@redux')) {
+                // Don't monitor redux actions
+            } else {
                 this.actionsCalled.push(action);
                 const actionObj = this._addAction(action.type);
                 actionObj.count++;

--- a/test/SagaTester.spec.js
+++ b/test/SagaTester.spec.js
@@ -10,8 +10,10 @@ describe('SagaTester', () => {
 	const someInitialState = { someKey : someInitialValue };
 	const someActionType   = 'SOME_ACTION_TYPE';
 	const OtherActionType  = 'OTHER_ACTION_TYPE';
+	const reduxActionType  = '@@redux/ACTION_TYPE';
 	const someAction       = { type : someActionType };
 	const OtherAction      = { type : OtherActionType };
+	const reduxAction      = { type : reduxActionType };
 
 	it('Populates store with a given initial state', () => {
 		const sagaTester = new SagaTester({initialState : someInitialState});
@@ -27,6 +29,20 @@ describe('SagaTester', () => {
 			OtherAction,
 		]);
 	});
+
+    it('Ignores redux action types by default', () => {
+		const sagaTester = new SagaTester({});
+		sagaTester.dispatch(reduxAction);
+		expect(sagaTester.getActionsCalled()).to.deep.equal([]);
+    });
+
+    it('Captures redux action types if configured', () => {
+		const sagaTester = new SagaTester({ignoreReduxActions: false});
+		sagaTester.dispatch(reduxAction);
+		expect(sagaTester.getActionsCalled()).to.deep.equal([
+			reduxAction,
+		]);
+    });
 
 	it('Uses the supplied reducers', () => {
 		const someFinalValue = 'SOME_FINAL_VALUE';


### PR DESCRIPTION
Per #7, the `ignoreReduxActions` flag allows callers to specify whether or not actions prefixed with '@@redux' should be captured and logged or not. By default they are not captured.

Cheers @3LOK 😄 