### PR TITLE
Remove namespace from wnpm-ci dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-dev": "mocha --watch --compilers js:babel-register",
     "compile": "babel -d dist/ src/",
     "build": ":",
-    "release": "npm install @wix/wnpm-ci && wnpm-release -- --no-shrinkwrap"
+    "release": "npm install wnpm-ci && wnpm-release -- --no-shrinkwrap"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Refs #33

This is only part of the fix because master on github is not up to date with what's on npm.