### PR TITLE
fix(package): move wnpm-ci to be dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-dev": "mocha --watch --compilers js:babel-register",
     "compile": "babel -d dist/ src/",
     "build": ":",
-    "release": "npm install wnpm-ci && wnpm-release -- --no-shrinkwrap"
+    "release": "wnpm-release --no-shrinkwrap"
   },
   "repository": {
     "type": "git",
@@ -42,7 +42,8 @@
     "nock": "^9.0.13",
     "node-fetch": "^1.6.3",
     "redux": "^3.6.0",
-    "redux-saga": "^0.15.3"
+    "redux-saga": "^0.15.3",
+    "wnpm-ci": "^6.2.52"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
before this change wnpm-ci was installed extraneously inside release script due to some legacy workaround that was created before wnpm-ci was a public package. this is redundant and now causes unwanted side effects since in npm@5 default behavior is to add things you install to dependencies (hence package.json was updated a moment before new version was published).

fixes #33