### PR TITLE
Enhance ignore pattern to avoid false positives

### DIFF
--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -43,7 +43,7 @@ export default class SagaIntegrationTester {
 
         // Middleware to store the actions and create promises
         const testerMiddleware = () => next => action => {
-            if (ignoreReduxActions && action.type.startsWith('@@redux') || action.type === UPDATE_STATE_TYPE) {
+            if (ignoreReduxActions && action.type.startsWith('@@redux/') || action.type === UPDATE_STATE_TYPE) {
                 // Don't monitor redux actions
             } else {
                 this.calledActions.push(action);


### PR DESCRIPTION
Some libraries, which are named `redux-*` use `@@redux-xxx/` prefix and redux-saga-tester is ignoring them even though it shouldn't.

Example: redux-form.