### PR TITLE
Cause waitFor to reject if awaited action is never called.

### DIFF
--- a/test/SagaTester.spec.js
+++ b/test/SagaTester.spec.js
@@ -196,6 +196,17 @@ describe('SagaTester', () => {
         });
     });
 
+    it('Rejects if saga completes without emiting awaited action', () => {
+        const sagaTester = new SagaTester({});
+        const NON_EMITTED_ACTION = 'NON_EMITTED_ACTION';
+        const emptySaga = function*() {
+            yield;
+        };
+        sagaTester.run(emptySaga);
+        const wait = sagaTester.waitFor(NON_EMITTED_ACTION);
+
+        return expect(wait).to.be.rejectedWith(Error, NON_EMITTED_ACTION);
+    });
 
     it('Reject a promise if exception has bubbled to root saga', () => {
         const reason = 'testcase';


### PR DESCRIPTION
### Description

Changes the `waitFor` promise to reject if the provided action is never called.

### Example

```js
it('must call SOME_ACTION_THAT_WILL_NEVER_FIRE', () => { 
    const saga = function*() { yield; }
    sagaTester.start(saga);
   return sagaTester.waitFor('SOME_ACTION_THAT_WILL_NEVER_FIRE');
});
```

**Before**

```
Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

- ❌  Not clear what went wrong. 
- ❌  Test hangs for 2 seconds before failing.

**After**

```
Error: SOME_ACTION_THAT_WILL_NEVER_FIRE was waited for but never called.
```

- ✅  Communicates that the expected behavior didn't occur.
- ✅  Fails as soon as the saga is exhausted.