### PR TITLE
fix: support immutable data structures with default reducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "eslint": "^3.19.0",
+    "immutable": "^3.8.2",
     "mocha": "^3.4.1",
     "nock": "^9.0.13",
     "node-fetch": "^1.6.3",

--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -34,6 +34,12 @@ export default class SagaIntegrationTester {
                     stateUpdate = action.payload;
                 }
 
+                // TODO: update this to use `.isImmutable()` as soon as v4 is released.
+                // http://facebook.github.io/immutable-js/docs/#/isImmutable
+                if (initialState.toJS) {
+                    return initialState.mergeDeep(stateUpdate);
+                }
+
                 return Object.assign({}, initialState, stateUpdate);
             }
 
@@ -67,7 +73,7 @@ export default class SagaIntegrationTester {
     }
 
     _handleRootSagaException(e) {
-        Object.keys(this.actionLookups).forEach(key =>this.actionLookups[key].reject(e));
+        Object.keys(this.actionLookups).forEach(key => this.actionLookups[key].reject(e));
     }
 
     _addAction(actionType, futureOnly = false) {

--- a/test/SagaTester.spec.js
+++ b/test/SagaTester.spec.js
@@ -1,5 +1,6 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised   from 'chai-as-promised';
+import { fromJS } from 'immutable';
 
 import SagaTester, { resetAction } from '../src/SagaTester';
 
@@ -26,6 +27,7 @@ describe('SagaTester', () => {
         const sagaTester = () => new SagaTester({ options: { logger: 42 }});
         expect(sagaTester).to.throw('`options.logger` passed to the Saga middleware is not a function!');
     });
+
     it('Populates store with a given initial state', () => {
         const sagaTester = new SagaTester({initialState : someInitialState});
         expect(sagaTester.getState()).to.deep.equal(someInitialState);
@@ -67,7 +69,7 @@ describe('SagaTester', () => {
         expect(sagaTester.getState()).to.deep.equal({someKey : someFinalValue, someOtherKey: 1234});
     });
 
-    it('uses a reducer as a function if provided', () => {
+    it('Uses a reducer as a function if provided', () => {
         let wasReducerCalled = false;
         const reducerFn = () => wasReducerCalled = true;
 
@@ -333,5 +335,17 @@ describe('SagaTester', () => {
         expect(newState.someReducer.foo).to.equal('bar');
         expect(newState.someReducer.nestedFoo).to.deep.equal({bo: 'horseman'});
         expect(sagaTester.getCalledActions().length).to.equal(0);
+    });
+
+    it('Handles immutable data structures with the default reducer', () => {
+        const initialState = fromJS({ foo: 'initial' });
+        const expectedState = { foo: 'bar' };
+
+        const sagaTester = new SagaTester({ initialState });
+        sagaTester.updateState(expectedState);
+        const newState = sagaTester.getState();
+
+        expect(newState.toJS).to.be.a('function');
+        expect(newState.toJS()).to.deep.equal(expectedState);
     });
 });


### PR DESCRIPTION
- added test case for handling immutable data structures with the default reducer
- add logic to handle immutable data structures with the default reducer