### PR TITLE
Return shallow copy of array in getCalledActions()

### DIFF
--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -141,7 +141,7 @@ export default class SagaIntegrationTester {
     }
 
     getCalledActions() {
-        return this.calledActions;
+        return this.calledActions.slice(); // shallow copy
     }
 
     getLatestCalledAction() {

--- a/test/SagaTester.spec.js
+++ b/test/SagaTester.spec.js
@@ -43,6 +43,17 @@ describe('SagaTester', () => {
         ]);
     });
 
+    it('Does not return internal reference to the list of actions', () => {
+        const sagaTester = new SagaTester({});
+        sagaTester.dispatch(someAction);
+        sagaTester.dispatch(otherAction);
+        sagaTester.getCalledActions().reverse();
+        expect(sagaTester.getCalledActions()).to.deep.equal([
+            someAction,
+            otherAction,
+        ]);
+    });
+
     it('Ignores redux action types by default', () => {
         const sagaTester = new SagaTester({});
         sagaTester.dispatch(reduxAction);


### PR DESCRIPTION
This fixes a problem where the user might accidentally alter the calledActions array inside SagaTester. getCalledActions() returned reference to the array so any function that modifies array in place (like Array.sort() or Array.reverse()) would modify the internal calledActions array too. This broke any further calls to getCalledActions() since the actions in the array were not guaranteed to be in order anymore.

The test case should make the problem quite clear.