### PR TITLE
Return the resolved result of action dispatches

### DIFF
--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -137,7 +137,7 @@ export default class SagaIntegrationTester {
     }
 
     dispatch(action) {
-        this.store.dispatch(action);
+        return this.store.dispatch(action);
     }
 
     getState() {

--- a/test/SagaTester.spec.js
+++ b/test/SagaTester.spec.js
@@ -71,6 +71,12 @@ describe('SagaTester', () => {
         expect(sagaTester.getCalledActions()).to.deep.equal([]);
     });
 
+    it('Dispatch returns the result of dispatching the action', () => {
+        const sagaTester = new SagaTester();
+        const action = sagaTester.dispatch(reduxAction);
+        expect(action).to.equal(reduxAction);
+    });
+
     it('Captures redux action types if configured', () => {
         const sagaTester = new SagaTester({ignoreReduxActions: false});
         sagaTester.dispatch(reduxAction);


### PR DESCRIPTION
I have an action that should return a promise when it is dispatched and the middleware intercepts it. I want to write a test case that verifies that dispatching an action returns a promise that resolves when a mocked request completes. My actual use case is slightly different but modifying an example off of `redux-saga-requests`

```js
import SagaTester from 'redux-saga-tester';
import { requestsPromiseMiddleware, watchRequests } from 'redux-saga-requests';

const sagaTester = new SagaTester({
  initialState,
  reducers: { store: reducer },
  middlewares: [requestsPromiseMiddleware],
});

sagaTester.start(watchRequests);

// My action
const fetchBooks = () => ({
  type: FETCH_BOOKS,
  request: { url: '/books'},
  meta: {
    asPromise: true,
  },
});
```

With the code above, I'd expect to be able to do this in a test case. This MR makes this possible by returning the resolved value from redux and any middleware

```js
const fetchBookPromise = sagaTester.dispatch(fetchBooks);
fetchBookPromise.then(() => {
  // ...
});
```